### PR TITLE
Refact: env variable management

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -64,6 +64,8 @@ config :logger, :default_formatter,
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
+config :blocks_analytics, ogmios_url: System.get_env("OGMIOS_URL", nil)
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -110,4 +110,6 @@ if config_env() == :prod do
   #     config :swoosh, :api_client, Swoosh.ApiClient.Hackney
   #
   # See https://hexdocs.pm/swoosh/Swoosh.html#module-installation for details.
+  #
+  config :blocks_analytics, ogmios_url: System.fetch_env!("OGMIOS_URL")
 end

--- a/lib/blocks_analytics/chain_sync_client.ex
+++ b/lib/blocks_analytics/chain_sync_client.ex
@@ -11,7 +11,14 @@ defmodule BlocksAnalytics.ChainSyncClient do
   require Logger
 
   def start_link(opts) do
-    Xogmios.start_chain_sync_link(__MODULE__, opts)
+    if Keyword.get(opts, :url) do
+      Xogmios.start_chain_sync_link(__MODULE__, opts)
+    else
+      # During test runs, this module should NOT be
+      # automatically started upon application boot and
+      # instead started with start_supervised/2
+      :ignore
+    end
   end
 
   @impl true


### PR DESCRIPTION
Some refactoring base on the https://github.com/wowica/blocks/pull/11/commits/791a8ff70ece74c01902e77d688d74a4834fd134 commit.

Our initial purpose was to use it on our `application.ex`:

```elixir
Application.get_env(:blocks, :ogmios_url)
```

I wasn't able to make it work, therefore we stick with the `fetch_env!/1` as below:

```elixir
defp ogmios_connection_url() do
  System.fetch_env!("OGMIOS_URL")
end
```