### PR TITLE
Change Data Type of ada_output fees columns

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir v1.18.0
-erlang 26.2.1
+erlang 27.1.3
+elixir 1.18.0

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ We are going to follow the same best practices the [Plausible](https://github.co
 
 Here is a great opportunity to read the [ClickHouse - Lightning Fast Analytics for Everyone](https://www.vldb.org/pvldb/vol17/p3731-schulze.pdf) paper.
 
-There's also this post by [Andy LeClair](https://andyleclair.dev/posts/2025/01-21-things-you-can-do-with-ecto.html) describring on how to use some [ecto_ch](https://github.com/plausible/ecto_ch) capabilities powered by ClickHouse.
+There's also this post by [Andy LeClair](https://andyleclair.dev/posts/2025/01-21-things-you-can-do-with-ecto.html) describing on how to use some [ecto_ch](https://github.com/plausible/ecto_ch) capabilities powered by ClickHouse.
 
 The initial idea is to fetch the Cardano Block, use the [ecto_ch](https://github.com/plausible/ecto_ch) to persists the data appropriately for timeseries analysis and then, analyse it with DuckDB.
 

--- a/lib/blocks_analytics/extract.ex
+++ b/lib/blocks_analytics/extract.ex
@@ -18,21 +18,16 @@ defmodule BlocksAnalytics.Extract do
       |> Stream.flat_map(fn tx -> tx["outputs"] end)
       |> Stream.map(fn output -> output["value"]["ada"]["lovelace"] end)
       |> Enum.sum()
-      |> Decimal.div(1_000_000)
-      |> Number.Delimit.number_to_delimited(precision: 0)
 
     fees =
       Stream.map(block["transactions"], fn tx ->
         tx["fee"]["ada"]["lovelace"]
       end)
       |> Enum.sum()
-      |> Decimal.div(1_000_000)
-      |> Decimal.round(2)
-      |> to_string()
 
     new_block = %{
       block_id: block["id"],
-      block_size: Decimal.div(block["size"]["bytes"], 1000) |> Decimal.round(1) |> to_string,
+      block_size: block["size"]["bytes"],
       block_height: block["height"],
       block_slot: block["slot"],
       issuer: normalize_issuer(block["issuer"]),

--- a/lib/blocks_analytics/schemas/block.ex
+++ b/lib/blocks_analytics/schemas/block.ex
@@ -6,13 +6,13 @@ defmodule BlocksAnalytics.Schemas.Block do
 
   @type t :: %__MODULE__{
           block_id: String.t(),
-          block_size: String.t(),
+          block_size: integer(),
           block_height: integer(),
           block_slot: integer(),
           issuer: String.t(),
           tx_count: integer(),
-          ada_output: String.t(),
-          fees: String.t(),
+          ada_output: integer(),
+          fees: integer(),
           date_time: NaiveDateTime.t(),
           inserted_at: NaiveDateTime.t(),
           __meta__: Ecto.Schema.Metadata.t()
@@ -21,13 +21,13 @@ defmodule BlocksAnalytics.Schemas.Block do
   @primary_key false
   schema "blocks" do
     field(:block_id, :string)
-    field(:block_size, :string)
+    field(:block_size, Ch, type: "UInt32")
     field(:block_height, Ch, type: "UInt64")
     field(:block_slot, Ch, type: "UInt64")
     field(:issuer, :string)
     field(:tx_count, Ch, type: "UInt32")
-    field(:ada_output, :string)
-    field(:fees, :string)
+    field(:ada_output, Ch, type: "UInt32")
+    field(:fees, Ch, type: "UInt32")
     field(:date_time, Ch, type: "DateTime")
     field(:inserted_at, Ch, type: "DateTime")
   end

--- a/priv/clickhouse_repo/migrations/20250708173826_create_blocks_table.exs
+++ b/priv/clickhouse_repo/migrations/20250708173826_create_blocks_table.exs
@@ -20,13 +20,13 @@ defmodule BlocksAnalytics.ClickhouseRepo.Migrations.CreateBlocksTable do
                            """
                          ) do
       add(:block_id, :string)
-      add(:block_size, :string)
+      add(:block_size, :UInt32)
       add(:block_height, :UInt64)
       add(:block_slot, :UInt64)
       add(:issuer, :string)
       add(:tx_count, :UInt32)
-      add(:ada_output, :string)
-      add(:fees, :string)
+      add(:ada_output, :UInt32)
+      add(:fees, :UInt32)
       add(:date_time, :naive_datetime)
       add(:inserted_at, :naive_datetime)
     end


### PR DESCRIPTION
These columns were with string type. We changed to integer and preserved the same scale as the original generated blocks.

We removed the divisors as well.

Need to plan how to present these values.